### PR TITLE
add orig_name property to interfaces

### DIFF
--- a/defs.pxd
+++ b/defs.pxd
@@ -568,6 +568,7 @@ cdef extern from "sys/sockio.h":
         SIOCSIFNAME
         SIOCSIFDESCR
         SIOCGIFDESCR
+        SIOCGIFORIGNAME
         SIOCAIFADDR
         SIOCADDMULTI
         SIOCDELMULTI

--- a/netif.pyx
+++ b/netif.pyx
@@ -1001,6 +1001,15 @@ cdef class NetworkInterface(object):
         self.name = name
         self.nameb = name.encode('ascii')
 
+    property orig_name:
+        def __get__(self):
+            cdef defs.ifreq ifr
+            memset(&ifr, 0, cython.sizeof(ifr))
+            strcpy(ifr.ifr_name, self.nameb)
+            if self.ioctl(defs.SIOCGIFORIGNAME, <void*>&ifr) == -1:
+                raise OSError(errno, os.strerror(errno))
+            return ifr.ifr_name.decode('ascii')
+
 
 class CarpConfig(object):
     def __init__(self, vhid, addr=None, advbase=None, advskew=None, key=None, state=None):


### PR DESCRIPTION
This uses the new SIOCGIFORIGNAME interface ioctl to
retrieve an interface's original name.  This is a building
block to allow finding the highest bridge or other cloning
device currently in the system, so as to predict the next
one that would be created.

Ticket: #19229

---
@jceel The other half of the fix (obviously order dependent, also not tested yet, this is more for you to review)